### PR TITLE
Added code for creating the logs directory if it does not exist. Prev…

### DIFF
--- a/cmd/mybittorrent/main.go
+++ b/cmd/mybittorrent/main.go
@@ -13,7 +13,20 @@ var logFile *os.File
 func init() {
 	// Open a file for logging
 	var err error
+	logDir := "logs"
+
+	if _, err = os.Stat(logDir); os.IsNotExist(err) {
+		err = os.Mkdir(logDir, 0755)
+
+		if err != nil {
+			log.Fatalf("Failed to create logs directory: %v", err)
+		}
+
+		log.Tracef("Created logs directory: %s", logDir)
+	}
+
 	logFile, err = os.OpenFile("logs/app.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+
 	if err != nil {
 		log.Fatalf("Failed to open log file: %v", err)
 	}


### PR DESCRIPTION
…iously, if the directory did not exist, the program would crash when running a command such as './bittorrent decode 5:hello'.