### PR TITLE
Made the public Decode function private and created a new public Deco…

### DIFF
--- a/cmd/mybittorrent/logic.go
+++ b/cmd/mybittorrent/logic.go
@@ -19,7 +19,7 @@ import (
 )
 
 func decodeBencodedString(encoding string) {
-	decoded, _, err := bencode.Decode(encoding, 0)
+	decoded, err := bencode.Decode(encoding)
 	if err != nil {
 		log.Fatalf("Error decoding bencode: %v", err)
 	}

--- a/internal/bencode/decode.go
+++ b/internal/bencode/decode.go
@@ -54,7 +54,7 @@ func decodeList(bencode string, start int) (list []interface{}, index int, err e
 		}
 
 		var result interface{}
-		result, index, err = Decode(bencode, index)
+		result, index, err = decode(bencode, index)
 		if err != nil {
 			return nil, index, err
 		}
@@ -81,7 +81,7 @@ func decodeDict(bencode string, start int) (dict map[string]interface{}, index i
 
 		// Get key
 		var key, value interface{}
-		key, index, err = Decode(bencode, index)
+		key, index, err = decode(bencode, index)
 		if err != nil {
 			return nil, index, err
 		}
@@ -93,7 +93,7 @@ func decodeDict(bencode string, start int) (dict map[string]interface{}, index i
 		}
 
 		// Get value
-		value, index, err = Decode(bencode, index)
+		value, index, err = decode(bencode, index)
 		if err != nil {
 			return nil, index, err
 		}
@@ -104,7 +104,7 @@ func decodeDict(bencode string, start int) (dict map[string]interface{}, index i
 	return dict, index + 1, nil
 }
 
-func Decode(bencode string, start int) (result interface{}, index int, err error) {
+func decode(bencode string, start int) (result interface{}, index int, err error) {
 	switch bencode[start] {
 	case 'i':
 		return decodeInt(bencode, start)
@@ -115,4 +115,9 @@ func Decode(bencode string, start int) (result interface{}, index int, err error
 	default:
 		return decodeString(bencode, start)
 	}
+}
+
+func Decode(bencode string) (result interface{}, err error) {
+	result, _, err = decode(bencode, 0)
+	return result, err
 }

--- a/internal/torrent/torrent.go
+++ b/internal/torrent/torrent.go
@@ -39,7 +39,7 @@ func Open(filePath string) *Torrent {
 		log.Fatal(fmt.Sprintf("Error reading file: %v\n", err))
 	}
 
-	decoding, _, err := bencode.Decode(string(bytes), 0)
+	decoding, err := bencode.Decode(string(bytes))
 	if err != nil {
 		log.Fatal(fmt.Sprintf("Error decoding file: %v\n", err))
 	}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -67,7 +67,7 @@ func sendTrackerRequest(baseURL *url.URL) []byte {
 
 func parseResponse(body []byte) (int, []client.Client) {
 	// Decoding Body
-	encoding, _, err := bencode.Decode(string(body), 0)
+	encoding, err := bencode.Decode(string(body))
 	if err != nil {
 		log.Errorf("Error decoding body: %v", err)
 		return 0, nil


### PR DESCRIPTION
…de function that no longer accepts an index as its second parameter, and that no longer returns an index. This makes the function easier to understand when calling it from another package than its own.